### PR TITLE
Fix Focal CI (use catkin_tools)

### DIFF
--- a/.github/workflows/ci_focal.yml
+++ b/.github/workflows/ci_focal.yml
@@ -20,6 +20,7 @@ jobs:
     # industrial_ci uses Docker, so we don't need a specific Ubuntu version
     runs-on: ubuntu-latest
     env:
+      ADDITIONAL_DEBS: "python3-osrf-pycommon"
       BUILDER: catkin_tools
       CI_NAME: Ubuntu Focal
       OS_NAME: ubuntu

--- a/.github/workflows/ci_focal.yml
+++ b/.github/workflows/ci_focal.yml
@@ -20,6 +20,7 @@ jobs:
     # industrial_ci uses Docker, so we don't need a specific Ubuntu version
     runs-on: ubuntu-latest
     env:
+      BUILDER: catkin_tools
       CI_NAME: Ubuntu Focal
       OS_NAME: ubuntu
       OS_CODE_NAME: focal


### PR DESCRIPTION
This works around the issue where (for some reason) `abb_librws` isn't resolved to the package present in the upstream workspace when `industrial_ci` starts the build of the target workspace.

Instead of using Colcon, this uses `catkin_tools`.

As there is an issue with the `osrf-pycommon` dependency on Focal with `catkin_tools`, we install that manually ourselves (in 1992ee62).
