### PR TITLE
Depend on specific versions of packages

### DIFF
--- a/pkgs.repos
+++ b/pkgs.repos
@@ -2,15 +2,15 @@ repositories:
   abb_libegm:
    type: git
    url: https://github.com/ros-industrial/abb_libegm.git
-   version: master
+   version: e0b8c3b0
   abb_librws:
    type: git
    url: https://github.com/ros-industrial/abb_librws.git
-   version: master
+   version: 3a5914ef
   abb_egm_rws_managers:
    type: git
    url: https://github.com/ros-industrial/abb_egm_rws_managers.git
-   version: master
+   version: 7d69d3dd
   abb_robot_driver:
    type: git
    url: https://github.com/ros-industrial/abb_robot_driver.git
@@ -18,4 +18,4 @@ repositories:
   abb_robot_driver_interfaces:
    type: git
    url: https://github.com/ros-industrial/abb_robot_driver_interfaces.git
-   version: master
+   version: 0.5.1


### PR DESCRIPTION
Instead of tracking named `HEAD`s, specify dependencies at versions which are *known-good*.

This does increase maintenance, as the version fields will have to be updated when dependencies are updated, but keeps `abb_robot_driver` stable, even if dependencies change.
