### PR TITLE
Depend on 0.5.3 release of the interfaces

### DIFF
--- a/pkgs.repos
+++ b/pkgs.repos
@@ -18,4 +18,4 @@ repositories:
   abb_robot_driver_interfaces:
    type: git
    url: https://github.com/ros-industrial/abb_robot_driver_interfaces.git
-   version: 0.5.1
+   version: 0.5.3


### PR DESCRIPTION
As per subject.

I'm going to open a follow-up PR for a from-source build but with the released version of the `interfaces` packages.
