### PR TITLE
Only need one interface

### DIFF
--- a/abb_robot_bringup_examples/README.md
+++ b/abb_robot_bringup_examples/README.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-The ROS nodes included in [abb_robot_driver](https://github.com/ros-industrial/abb_robot_driver) can only interact with ABB robots that are supported by these interfaces:
+The ROS nodes included in [abb_robot_driver](https://github.com/ros-industrial/abb_robot_driver) can only interact with ABB robots that are supported by one (or more) of these interfaces:
 
 - *Robot Web Services* (`RWS`) `1.0`:
   - Available in `IRC5` controllers with `RobotWare 6` systems.


### PR DESCRIPTION
As a brand new ABB user this confused me at first. I think the README should specify that you only need one of the listed interfaces.  (if that is true. If it's not true, then I can adjust this PR to say both are required.)